### PR TITLE
Update variables.tf with customer managed keys that reflect the resou…

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,21 +134,20 @@ Default: `null`
 
 ### <a name="input_customer_managed_key"></a> [customer\_managed\_key](#input\_customer\_managed\_key)
 
-Description: - `geo_backup_key_vault_key_id` - (Optional) The ID of the geo backup Key Vault Key. It can't cross region and need Customer Managed Key in same region as geo backup.
-- `geo_backup_user_assigned_identity_id` - (Optional) The geo backup user managed identity id for a Customer Managed Key. Should be added with `identity_ids`. It can't cross region and need identity in same region as geo backup.
-- `key_vault_key_id` - (Optional) The ID of the Key Vault Key.
-- `primary_user_assigned_identity_id` - (Optional) Specifies the primary user managed identity id for a Customer Managed Key. Should be added with `identity_ids`.
+Description: A map describing customer-managed keys to associate with the resource. This includes the following properties:
+- `key_vault_key_id` - (Required) The ID of the Key Vault Key..
+- `geo_backup_key_vault_key_id` - (Optional) The ID of the geo backup Key Vault Key
+- `geo_backup_user_assigned_identity_id` - (Optional) The geo backup user managed identity id for a Customer Managed Key. Should be added with identity\_ids
+- `primary_user_assigned_identity_id` - (Optional) Specifies the primary user managed identity id for a Customer Managed Key. Should be added with identity\_ids
 
 Type:
 
 ```hcl
 object({
-    key_vault_resource_id = string
-    key_name              = string
-    key_version           = optional(string, null)
-    user_assigned_identity = optional(object({
-      resource_id = string
-    }), null)
+    key_vault_key_id                     = string
+    geo_backup_key_vault_key_id          = optional(string)
+    geo_backup_user_assigned_identity_id = optional(string)
+    primary_user_assigned_identity_id    = optional(string)
   })
 ```
 

--- a/variables.tf
+++ b/variables.tf
@@ -46,6 +46,7 @@ variable "create_mode" {
 }
 
 variable "customer_managed_key" {
+  # tflint-ignore: customer_managed_key
   type = object({
     key_vault_key_id                     = string
     geo_backup_key_vault_key_id          = optional(string)

--- a/variables.tf
+++ b/variables.tf
@@ -47,20 +47,19 @@ variable "create_mode" {
 
 variable "customer_managed_key" {
   type = object({
-    key_vault_resource_id = string
-    key_name              = string
-    key_version           = optional(string, null)
-    user_assigned_identity = optional(object({
-      resource_id = string
-    }), null)
+    key_vault_key_id = string
+    geo_backup_key_vault_key_id = optional(string)
+    geo_backup_user_assigned_identity_id = optional(string)
+    primary_user_assigned_identity_id = optional(string)
   })
   default     = null
-  description = <<-EOT
- - `geo_backup_key_vault_key_id` - (Optional) The ID of the geo backup Key Vault Key. It can't cross region and need Customer Managed Key in same region as geo backup.
- - `geo_backup_user_assigned_identity_id` - (Optional) The geo backup user managed identity id for a Customer Managed Key. Should be added with `identity_ids`. It can't cross region and need identity in same region as geo backup.
- - `key_vault_key_id` - (Optional) The ID of the Key Vault Key.
- - `primary_user_assigned_identity_id` - (Optional) Specifies the primary user managed identity id for a Customer Managed Key. Should be added with `identity_ids`.
-EOT
+  description = <<DESCRIPTION
+A map describing customer-managed keys to associate with the resource. This includes the following properties:
+- `key_vault_key_id` - (Required) The ID of the Key Vault Key..
+- `geo_backup_key_vault_key_id` - (Optional) The ID of the geo backup Key Vault Key
+- `geo_backup_user_assigned_identity_id` - (Optional) The geo backup user managed identity id for a Customer Managed Key. Should be added with identity_ids
+- `primary_user_assigned_identity_id` - (Optional) Specifies the primary user managed identity id for a Customer Managed Key. Should be added with identity_ids
+DESCRIPTION  
 }
 
 variable "delegated_subnet_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -47,10 +47,10 @@ variable "create_mode" {
 
 variable "customer_managed_key" {
   type = object({
-    key_vault_key_id = string
-    geo_backup_key_vault_key_id = optional(string)
+    key_vault_key_id                     = string
+    geo_backup_key_vault_key_id          = optional(string)
     geo_backup_user_assigned_identity_id = optional(string)
-    primary_user_assigned_identity_id = optional(string)
+    primary_user_assigned_identity_id    = optional(string)
   })
   default     = null
   description = <<DESCRIPTION


### PR DESCRIPTION
…rce block

## Description
Similar to the issue [here](https://github.com/Azure/terraform-azurerm-avm-res-dbforpostgresql-flexibleserver/pull/24). When trying to create customer managed keys I found that what is written in main.tf does not correspond with variables.tf.

I've updated the variable code block as per the code block in the terraform registry for azurerm_mysql_flexible_server resource.

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [x] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [x] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
