### PR TITLE
feat: support write-only administrator password attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,22 @@ Type: `string`
 
 Default: `null`
 
+### <a name="input_administrator_password_wo"></a> [administrator\_password\_wo](#input\_administrator\_password\_wo)
+
+Description: (Optional) Write-only administrator password for MySQL Flexible Server. Avoids storing password in state. Mutually exclusive with administrator\_password.
+
+Type: `string`
+
+Default: `null`
+
+### <a name="input_administrator_password_wo_version"></a> [administrator\_password\_wo\_version](#input\_administrator\_password\_wo\_version)
+
+Description: (Optional) Version of the write-only administrator password. Used to rotate password.
+
+Type: `number`
+
+Default: `null`
+
 ### <a name="input_backup_retention_days"></a> [backup\_retention\_days](#input\_backup\_retention\_days)
 
 Description: (Optional) The backup retention days for the MySQL Flexible Server. Possible values are between `1` and `35` days. Defaults to `7`.

--- a/examples/default/README.md
+++ b/examples/default/README.md
@@ -64,11 +64,13 @@ resource "random_password" "admin_password" {
 module "mysql_server" {
   source = "../../"
 
-  location               = azurerm_resource_group.this.location
-  name                   = module.naming.mysql_server.name_unique
-  resource_group_name    = azurerm_resource_group.this.name
-  administrator_login    = "mysqladmin"
-  administrator_password = random_password.admin_password.result
+  location            = azurerm_resource_group.this.location
+  name                = module.naming.mysql_server.name_unique
+  resource_group_name = azurerm_resource_group.this.name
+  administrator_login = "mysqladmin"
+  # administrator_password = random_password.admin_password.result
+  administrator_password_wo         = random_password.admin_password.result
+  administrator_password_wo_version = 1 # increment to rotate password
   # source             = "Azure/avm-<res/ptn>-<name>/azurerm"
   # ...
   enable_telemetry = var.enable_telemetry # see variables.tf

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -57,11 +57,13 @@ resource "random_password" "admin_password" {
 module "mysql_server" {
   source = "../../"
 
-  location               = azurerm_resource_group.this.location
-  name                   = module.naming.mysql_server.name_unique
-  resource_group_name    = azurerm_resource_group.this.name
-  administrator_login    = "mysqladmin"
-  administrator_password = random_password.admin_password.result
+  location            = azurerm_resource_group.this.location
+  name                = module.naming.mysql_server.name_unique
+  resource_group_name = azurerm_resource_group.this.name
+  administrator_login = "mysqladmin"
+  # administrator_password = random_password.admin_password.result
+  administrator_password_wo         = random_password.admin_password.result
+  administrator_password_wo_version = 1 # increment to rotate password
   # source             = "Azure/avm-<res/ptn>-<name>/azurerm"
   # ...
   enable_telemetry = var.enable_telemetry # see variables.tf

--- a/main.tf
+++ b/main.tf
@@ -12,6 +12,8 @@ resource "azurerm_mysql_flexible_server" "this" {
   resource_group_name               = var.resource_group_name
   administrator_login               = var.administrator_login
   administrator_password            = var.administrator_password
+  administrator_password_wo         = var.administrator_password_wo
+  administrator_password_wo_version = var.administrator_password_wo_version
   backup_retention_days             = var.backup_retention_days
   create_mode                       = var.create_mode
   delegated_subnet_id               = var.delegated_subnet_id

--- a/variables.tf
+++ b/variables.tf
@@ -33,6 +33,19 @@ variable "administrator_password" {
   sensitive   = true
 }
 
+variable "administrator_password_wo" {
+  type        = string
+  default     = null
+  description = "(Optional) Write-only administrator password for MySQL Flexible Server. Avoids storing password in state. Mutually exclusive with administrator_password."
+  sensitive   = true
+}
+
+variable "administrator_password_wo_version" {
+  type        = number
+  default     = null
+  description = "(Optional) Version of the write-only administrator password. Used to rotate password."
+}
+
 variable "backup_retention_days" {
   type        = number
   default     = null


### PR DESCRIPTION
## Description

This PR adds support for the new write-only administrator password attributes (`administrator_password_wo` and `administrator_password_wo_version`) for Azure MySQL Flexible Server, which avoid storing the administrator password in Terraform state.

## Changes

### New Variables
- **`administrator_password_wo`** (string, optional): Write-only administrator password for MySQL Flexible Server. Avoids storing password in state. Mutually exclusive with `administrator_password`.
- **`administrator_password_wo_version`** (number, optional): Version of the write-only administrator password. Used to rotate password.

### Updated Files
- `variables.tf`: Added new input variables
- `main.tf`: Added new attributes to azurerm_mysql_flexible_server resource
- `README.md`: Updated documentation with new variables
- `examples/default/main.tf`: Updated example to demonstrate new write-only password usage
- `examples/default/README.md`: Updated example documentation

### Provider Schema Verification
Confirmed that the azurerm provider schema includes these write-only attributes for the `azurerm_mysql_flexible_server` resource.

## Testing

- ✅ All AVM linting checks passed
- ✅ TFLint validation passed for root module and all examples
- ✅ Documentation generation completed successfully
- ✅ Code formatting and avmfix checks passed
- ⚠️ Well-architected checks skipped (require Azure authentication)

## Related Issue

Resolves the feature request to support write-only administrator password attributes that prevent sensitive data from being stored in Terraform state files.

## Breaking Changes

None. This is a backward-compatible addition. Existing configurations using `administrator_password` will continue to work as before.