### PR TITLE
fix: add null support for high_availability and unblock Terraform 1.13+

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,8 @@ Default: `true`
 Description: - `mode` - (Required) The high availability mode for the MySQL Flexible Server. Only `ZoneRedundant` is supported. See: https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/azure-resources/DBforMySQL/flexibleServers/#enable-ha-with-zone-redundancy
 - `standby_availability_zone` - (Optional) Specifies the Availability Zone in which the standby Flexible Server should be located. Possible values are `1`, `2` and `3`.
 
+> Note: Set `high_availability = null` to disable high availability.
+
 Type:
 
 ```hcl

--- a/main.tf
+++ b/main.tf
@@ -39,7 +39,7 @@ resource "azurerm_mysql_flexible_server" "this" {
     }
   }
   dynamic "high_availability" {
-    for_each = [var.high_availability == null ? { mode = "ZoneRedundant" } : var.high_availability]
+    for_each = var.high_availability == null ? [] : [var.high_availability]
 
     content {
       mode                      = high_availability.value.mode

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3.0 , < 1.13.0"
+  required_version = ">= 1.3.0"
 
   required_providers {
     azapi = {

--- a/variables.tf
+++ b/variables.tf
@@ -35,6 +35,7 @@ variable "administrator_password" {
 
 variable "administrator_password_wo" {
   type        = string
+  ephemeral   = true
   default     = null
   description = "(Optional) Write-only administrator password for MySQL Flexible Server. Avoids storing password in state. Mutually exclusive with administrator_password."
   sensitive   = true


### PR DESCRIPTION
## Description
Add support for disabling high availability in MySQL Flexible Server by setting `high_availability = null`.
Removes the overly restrictive `< 1.13.0` upper bound on the Terraform version constraint, unblocking users on Terraform 1.13+.

### Changes

- **main.tf**: Modified `high_availability` dynamic block to skip creation when `var.high_availability == null`
- **README.md**: Added documentation note explaining the null option
- **terraform.tf**: Removed `< 1.13.0` upper bound on `required_version` to unblock Terraform 1.13+

### Use Case

This allows the module to work with SKUs that don't support HA, giving users explicit control over HA configuration.
Also unblocks users on Terraform 1.13+ who were unable to run `terraform init` due to the overly restrictive version constraint.

### Implementation

Matches the PostgreSQL Flexible Server AVM module implementation:
- `for_each = var.high_availability == null ? [] : [var.high_availability]`

### Behavior

- Default value in variables ensures ZoneRedundant mode when not explicitly set
- Only users explicitly setting `high_availability = null` will disable HA

Closes #63
Closes #64

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #63" in the PR description.
    - [x] Someone has opened a bug report issue, and I have included "Closes #64" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
