### PR TITLE
Updated the terraform version

### DIFF
--- a/terraform.tf
+++ b/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3.0 , < 1.13.0"
+  required_version = ">= 1.3.0 , < 2.0"
 
   required_providers {
     azapi = {


### PR DESCRIPTION
This pull request updates the Terraform configuration to allow for newer versions of Terraform. The required version constraint has been relaxed to permit any version from 1.3.0 up to, but not including, 2.0.

Version compatibility update:

* [`terraform.tf`](diffhunk://#diff-ae3037560f46b85279fe53ff13896a24529afd8ffccd0911dfa366d0a4db9ec2L2-R2): Changed the `required_version` constraint to allow Terraform versions up to, but not including, 2.0 instead of capping at 1.13.0.