### PR TITLE
feat: add resource_fqdn output for MySQL Flexible Server FQDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -624,6 +624,10 @@ Default: `null`
 
 The following outputs are exported:
 
+### <a name="output_resource_fqdn"></a> [resource\_fqdn](#output\_resource\_fqdn)
+
+Description: The fully qualified domain name of the MySQL Flexible Server.
+
 ### <a name="output_resource_id"></a> [resource\_id](#output\_resource\_id)
 
 Description: The ID of the resoure

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,11 +1,11 @@
-output "resource_id" {
-  description = "The ID of the resoure"
-  value       = azurerm_mysql_flexible_server.this.id
-}
-
 output "resource_fqdn" {
   description = "The fully qualified domain name of the MySQL Flexible Server."
   value       = azurerm_mysql_flexible_server.this.fqdn
+}
+
+output "resource_id" {
+  description = "The ID of the resoure"
+  value       = azurerm_mysql_flexible_server.this.id
 }
 
 output "resource_name" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,6 +3,11 @@ output "resource_id" {
   value       = azurerm_mysql_flexible_server.this.id
 }
 
+output "resource_fqdn" {
+  description = "The fully qualified domain name of the MySQL Flexible Server."
+  value       = azurerm_mysql_flexible_server.this.fqdn
+}
+
 output "resource_name" {
   description = "The name of the resource"
   value       = azurerm_mysql_flexible_server.this.name


### PR DESCRIPTION
Closes #62

## Description

Adds a new output `resource_fqdn` that exposes the fully qualified domain name (`fqdn`) of the `azurerm_mysql_flexible_server` resource. This allows module consumers to directly reference the server FQDN for use in connection strings and other downstream configurations.

## Changes

- **`outputs.tf`**: Added `resource_fqdn` output referencing `azurerm_mysql_flexible_server.this.fqdn`
- **`README.md`**: Auto-regenerated via `terraform-docs` to include the new output in documentation

## Type of Change

- [x] Feature (non-breaking addition)
- [ ] Bug fix
- [ ] Breaking change

## Impact

- **Non-breaking**: Adding a new output does not affect existing configurations or state.
- **No migration required**: Existing users will see no plan changes.