### PR TITLE
fix: use correct PE resource for ASG association when DNS zone group is unmanaged

### DIFF
--- a/main.privateendpoint.tf
+++ b/main.privateendpoint.tf
@@ -85,5 +85,5 @@ resource "azurerm_private_endpoint_application_security_group_association" "this
   for_each = local.private_endpoint_application_security_group_associations
 
   application_security_group_id = each.value.asg_resource_id
-  private_endpoint_id           = azurerm_private_endpoint.this_managed_dns_zone_groups[each.value.pe_key].id
+  private_endpoint_id           = var.private_endpoints_manage_dns_zone_group ? azurerm_private_endpoint.this_managed_dns_zone_groups[each.value.pe_key].id : azurerm_private_endpoint.this_unmanaged_dns_zone_groups[each.value.pe_key].id
 }


### PR DESCRIPTION
## Description

Fixes #68

When `private_endpoints_manage_dns_zone_group` is set to `false`, the `azurerm_private_endpoint_application_security_group_association` resource fails with an `Invalid index` error because it is hardcoded to reference `azurerm_private_endpoint.this_managed_dns_zone_groups`, which has an empty `for_each` when DNS zone groups are not managed.

## Root Cause

In `main.privateendpoint.tf`, line 88 unconditionally references the managed DNS zone group PE resource:

```hcl
private_endpoint_id = azurerm_private_endpoint.this_managed_dns_zone_groups[each.value.pe_key].id
```

When `private_endpoints_manage_dns_zone_group = false`, PEs are created in `this_unmanaged_dns_zone_groups` instead, making the managed collection empty.

## Fix

Use a conditional expression to select the correct PE resource based on the `private_endpoints_manage_dns_zone_group` variable:

```hcl
private_endpoint_id = var.private_endpoints_manage_dns_zone_group ? azurerm_private_endpoint.this_managed_dns_zone_groups[each.value.pe_key].id : azurerm_private_endpoint.this_unmanaged_dns_zone_groups[each.value.pe_key].id
```

## Impact

- No change for users with the default `private_endpoints_manage_dns_zone_group = true`
- Users with `private_endpoints_manage_dns_zone_group = false` can now properly use ASG associations
- No breaking changes